### PR TITLE
Fix for case where publicURL is  = '/'

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,13 +98,20 @@ module.exports = (bundler) => {
 					}
 				}
 			}
+			
+			//handle case where public path is equal to '/'
+			// indexPath is used in generateSW
+			let indexPath = '/index.html';
+                          if(publicURL === '/'){			  	  
+                          indexPath = 'index.html'
+                        }
 
 			workbox.generateSW(
 				Object.assign({
 					globDirectory: outDir,
 					globPatterns: ['**\/*.{html,js,css,jpg,png}'],
 					swDest: swDest,
-					navigateFallback: publicURL+"/index.html",
+					navigateFallback: publicURL + indexPath,
 					clientsClaim: true,
 					skipWaiting: true,
 					"templatedUrls": {

--- a/index.js
+++ b/index.js
@@ -98,20 +98,17 @@ module.exports = (bundler) => {
 					}
 				}
 			}
-			
-			//handle case where public path is equal to '/'
-			// indexPath is used in generateSW
-			let indexPath = '/index.html';
-                          if(publicURL === '/'){			  	  
-                          indexPath = 'index.html'
-                        }
+
+			if(publicURL == "/"){
+				publicURL = "";
+			}
 
 			workbox.generateSW(
 				Object.assign({
 					globDirectory: outDir,
 					globPatterns: ['**\/*.{html,js,css,jpg,png}'],
 					swDest: swDest,
-					navigateFallback: publicURL + indexPath,
+					navigateFallback: publicURL+"/index.html",
 					clientsClaim: true,
 					skipWaiting: true,
 					"templatedUrls": {


### PR DESCRIPTION
Don't know if this is helpful. This stops the service worker outputting this this: 

```
workbox.routing.registerNavigationRoute("//index.html");

```
In the case where the publicURL variable in the source code is = '/'