### PR TITLE
README - fix syntac highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The remaining properties in this object will be passed to `generateSW` or `injec
 In `inject` mode, occurences of  `__PUBLIC` will be replaced with Parcel's public-url option. In this case, `swSrc` is also a required parameter.
 
 No configuration options are mandatory, the default configuration will work just fine. (Creating a service worker to precache all files in the output directory without runtime caching). With `strategy: "default"`, the default parameters passed to workbox-build are (which precaching all html, js, css, jpg and png files):
-```json
+```js
 {
     globDirectory: outDir,
     globPatterns: ["**/*.{html,js,css,jpg,png}"],
@@ -44,7 +44,7 @@ No configuration options are mandatory, the default configuration will work just
 }
 ```
 and with `inject`:
-```json
+```js
 {
     globDirectory: outDir,
     globPatterns: [
@@ -66,7 +66,7 @@ runtimeCaching: [
 ]
 ```
 becomes
-```json
+```js
 "runtimeCaching": [
     {
         "urlPattern": ["my-match\/api\.[0-9]+", "i"]


### PR DESCRIPTION
This will fix syntax highlighting:

![image](https://user-images.githubusercontent.com/96121/52337565-478c6900-2a08-11e9-82f7-8c86c461cba5.png)

to ➡️

![image](https://user-images.githubusercontent.com/96121/52337615-68ed5500-2a08-11e9-9e60-e02e7d056ee4.png)

